### PR TITLE
feat(validation): add SQL structure security rules

### DIFF
--- a/.github/workflows/php56-parse-smoke.yml
+++ b/.github/workflows/php56-parse-smoke.yml
@@ -1,0 +1,42 @@
+name: PHP 5.6 Parse and Smoke
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  php56-parse-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP 5.6
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '5.6'
+          coverage: none
+          tools: none
+
+      - name: Parse source files
+        run: find src -type f -name '*.php' -print0 | xargs -0 -n1 php -l
+
+      - name: Smoke SQL structure rules
+        run: |
+          php -r '
+          require "src/Rule.php";
+          require "src/Rules/SqlIdentifierRule.php";
+          require "src/Rules/SortDirectionRule.php";
+
+          $identifier = new \BitApps\WPValidator\Rules\SqlIdentifierRule();
+          $direction = new \BitApps\WPValidator\Rules\SortDirectionRule();
+
+          if (!$identifier->validate("sort_column")
+              || $identifier->validate("users.sort_column")
+              || !$direction->validate("DESC")
+              || $direction->validate("desc ")
+              || $direction->validate(0)) {
+              fwrite(STDERR, "PHP 5.6 SQL structure rule smoke check failed\n");
+              exit(1);
+          }
+          '

--- a/README.md
+++ b/README.md
@@ -167,14 +167,15 @@ Checks if the field under validation has a minimum value of `:min`.
     - For numeric data, the value corresponds to a given integer value.
     - For an array, the value corresponds to the count of the array.
 17. **`nullable`**<br/>
-Makes the field under validation as optional (allows to be null), but respects other validation rules if specified and value is not null.
+Skips later validation rules when the field is omitted, `null`, an empty string, or an empty array. A value of `false` continues through later validation rules.
 18. **`numeric`**<br/>
 Checks if the field under validation is a valid real number.
 19. **`required`**<br/>
 Checks if the field under validation is present and not empty. A field is "empty" if it meets one of the following criteria:
-    - The value is `NULL` or `FALSE`.
+    - The field is omitted or the value is `NULL`.
     - The value is an empty string.
-    - The value is an empty array or empty countable object.
+    - The value is an empty array.
+    - A value of `FALSE` is not empty and continues through validation.
 20. **`same:field`**<br/>
 Checks if the field under validation is equal to the specified `:other` attribute.
 21. **`size:value`**<br/>
@@ -211,9 +212,10 @@ sql_identifier validates one unqualified identifier segment. It does not quote S
 sort_direction validates asc/desc. It does not add an ORDER BY clause.
 sanitize:text and sanitize:key are not SQL-context security controls.
 Raw SQL still requires typed identifier handling in the database layer.
-nullable skips later rules for values the validator considers empty, including an
-empty string and empty array; do not use nullable for security-sensitive sort fields
-unless the request layer has already removed/defaulted empty input.
+nullable skips later rules for an omitted value, null, an empty string, or an empty
+array. A false value continues through later validation; do not use nullable for
+security-sensitive sort fields unless the request layer has already removed/defaulted
+empty input.
 
 ### Custom Validation Rule
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,34 @@ Checks if the field under validation has exactly the same size as `:size`.
 Checks if the given value is a string.
 23. **`uppercase`**<br/>
 Checks if the string value consists of all uppercase letters.
-24. **`url`**<br/>
+24. **`sql_identifier`**<br/>
+Validates one unqualified identifier segment. It does not quote SQL.
+25. **`sort_direction`**<br/>
+Validates `asc` or `desc`. It does not add an `ORDER BY` clause.
+26. **`url`**<br/>
 Checks if the value is a valid URL.
 
 Missing any validation rule that you need? Refer to the [Custom Validation Rule](#custom-validation-rule) section to know how you can create and use custom validation rules in your project alongside the library.
+
+### SQL Structure Validation
+
+Use `sql_identifier` and `sort_direction` to validate request fields that select a
+column and sort direction:
+
+```php
+$rules = [
+    'sortBy'    => ['required', 'string', 'sql_identifier'],
+    'sortOrder' => ['required', 'string', 'sort_direction'],
+];
+```
+
+sql_identifier validates one unqualified identifier segment. It does not quote SQL.
+sort_direction validates asc/desc. It does not add an ORDER BY clause.
+sanitize:text and sanitize:key are not SQL-context security controls.
+Raw SQL still requires typed identifier handling in the database layer.
+nullable skips later rules for values the validator considers empty, including an
+empty string and empty array; do not use nullable for security-sensitive sort fields
+unless the request layer has already removed/defaulted empty input.
 
 ### Custom Validation Rule
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -36,6 +36,10 @@ trait Helpers
         $current = &$data;
 
         foreach ($keys as $key) {
+            if (is_null($current)) {
+                $current = [];
+            }
+
             if (is_array($current) && !isset($current[$key])) {
                 $current[$key] = [];
             } elseif (is_object($current) && !isset($current->$key)) {

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -42,7 +42,11 @@ trait Helpers
                 $current->$key = new stdClass();
             }
 
-            $current = &$current[$key] ?? $current->$key;
+            if (is_array($current)) {
+                $current = &$current[$key];
+            } else {
+                $current = &$current->$key;
+            }
         }
 
         $current = $value;

--- a/src/Rules/SortDirectionRule.php
+++ b/src/Rules/SortDirectionRule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitApps\WPValidator\Rules;
+
+use BitApps\WPValidator\Rule;
+
+class SortDirectionRule extends Rule
+{
+    private $message = 'The :attribute must be asc or desc';
+
+    public function validate($value)
+    {
+        return is_string($value)
+            && in_array(strtolower($value), ['asc', 'desc'], true);
+    }
+
+    public function message()
+    {
+        return $this->message;
+    }
+}

--- a/src/Rules/SqlIdentifierRule.php
+++ b/src/Rules/SqlIdentifierRule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitApps\WPValidator\Rules;
+
+use BitApps\WPValidator\Rule;
+
+class SqlIdentifierRule extends Rule
+{
+    private $message = 'The :attribute must be a valid SQL identifier';
+
+    public function validate($value)
+    {
+        return is_string($value)
+            && preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/D', $value) === 1;
+    }
+
+    public function message()
+    {
+        return $this->message;
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -21,6 +21,20 @@ test('sets a nested array element by reference', function () {
         ]);
 });
 
+test('promotes a null root to a nested array element', function () {
+    $helpers = new HelpersTestHarness();
+    $data = null;
+
+    $result = $helpers->setNestedElement($data, ['a', 'b'], 'x');
+
+    expect($result)->toBe('x')
+        ->and($data)->toBe([
+            'a' => [
+                'b' => 'x',
+            ],
+        ]);
+});
+
 test('sets a nested object property by reference', function () {
     $helpers = new HelpersTestHarness();
     $data = new stdClass();

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use BitApps\WPValidator\Helpers;
+
+class HelpersTestHarness
+{
+    use Helpers;
+}
+
+test('sets a nested array element by reference', function () {
+    $helpers = new HelpersTestHarness();
+    $data = [];
+
+    $result = $helpers->setNestedElement($data, ['profile', 'name'], 'Ada');
+
+    expect($result)->toBe('Ada')
+        ->and($data)->toBe([
+            'profile' => [
+                'name' => 'Ada',
+            ],
+        ]);
+});
+
+test('sets a nested object property by reference', function () {
+    $helpers = new HelpersTestHarness();
+    $data = new stdClass();
+
+    $result = $helpers->setNestedElement($data, ['profile', 'name'], 'Ada');
+
+    expect($result)->toBe('Ada')
+        ->and($data)->toEqual((object) [
+            'profile' => (object) [
+                'name' => 'Ada',
+            ],
+        ]);
+});

--- a/tests/Rules/SortDirectionTest.php
+++ b/tests/Rules/SortDirectionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use BitApps\WPValidator\Rules\SortDirectionRule;
+
+dataset('valid sort directions', [
+    'asc',
+    'ASC',
+    'desc',
+    'DESC',
+]);
+
+dataset('invalid sort directions', [
+    ' asc',
+    'desc ',
+    [['asc']],
+    null,
+    'ascending',
+    'desc; DROP',
+    'desc nulls last',
+]);
+
+test('accepts asc and desc sort directions case-insensitively', function ($value) {
+    $rule = new SortDirectionRule();
+
+    expect($rule->validate($value))->toBeTrue();
+})->with('valid sort directions');
+
+test('rejects values that are not exact sort directions', function ($value) {
+    $rule = new SortDirectionRule();
+
+    expect($rule->validate($value))->toBeFalse();
+})->with('invalid sort directions');

--- a/tests/Rules/SqlIdentifierTest.php
+++ b/tests/Rules/SqlIdentifierTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use BitApps\WPValidator\Rules\SqlIdentifierRule;
+use BitApps\WPValidator\Validator;
+
+dataset('valid SQL identifiers', [
+    'id',
+    '_private_column',
+    'custom_field_12',
+    'owner_ID',
+]);
+
+dataset('invalid SQL identifiers', [
+    'IF(1=1,SLEEP(5),id)',
+    'id`,(SELECT sleep(22) )#',
+    'id; DROP TABLE users',
+    'users.id',
+    '`id`',
+    '1column',
+    'id-name',
+    '',
+    null,
+    [['id']],
+]);
+
+test('accepts a single valid SQL identifier segment', function ($value) {
+    $rule = new SqlIdentifierRule();
+
+    expect($rule->validate($value))->toBeTrue();
+})->with('valid SQL identifiers');
+
+test('rejects values that are not a single SQL identifier segment', function ($value) {
+    $rule = new SqlIdentifierRule();
+
+    expect($rule->validate($value))->toBeFalse();
+})->with('invalid SQL identifiers');
+
+test('resolves sql_identifier and returns its validation message', function () {
+    $validator = new Validator();
+
+    $validation = $validator->make(
+        ['column' => 'users.id'],
+        ['column' => ['sql_identifier']]
+    );
+
+    expect($validation->errors())->toBe([
+        'column' => ['The column must be a valid SQL identifier'],
+    ]);
+});

--- a/tests/SqlStructureValidationTest.php
+++ b/tests/SqlStructureValidationTest.php
@@ -33,8 +33,8 @@ test('returns the first labeled error for each malicious SQL structure value', f
             'sortOrder' => 'desc; DROP',
         ],
         [
-            'sortBy' => ['required', 'sql_identifier'],
-            'sortOrder' => ['required', 'sort_direction'],
+            'sortBy' => ['required', 'sql_identifier', 'uppercase'],
+            'sortOrder' => ['required', 'sort_direction', 'uppercase'],
         ],
         [],
         [

--- a/tests/SqlStructureValidationTest.php
+++ b/tests/SqlStructureValidationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use BitApps\WPValidator\Validator;
+
+dataset('nullable SQL structure values', [
+    'omitted field' => [[], [], false],
+    'null' => [['value' => null], ['value' => null], false],
+    'empty string' => [['value' => ''], ['value' => ''], false],
+    'empty array' => [['value' => []], ['value' => []], false],
+    'false' => [['value' => false], null, true],
+]);
+
+test('validates safe SQL structure values without changing them', function () {
+    $validator = (new Validator())->make(
+        ['sortBy' => 'custom_field_12', 'sortOrder' => 'DESC'],
+        [
+            'sortBy' => ['required', 'sql_identifier'],
+            'sortOrder' => ['required', 'sort_direction'],
+        ]
+    );
+
+    expect($validator->fails())->toBeFalse()
+        ->and($validator->validated())->toBe([
+            'sortBy' => 'custom_field_12',
+            'sortOrder' => 'DESC',
+        ]);
+});
+
+test('returns the first labeled error for each malicious SQL structure value', function () {
+    $validator = (new Validator())->make(
+        [
+            'sortBy' => 'id`,(SELECT sleep(22) )#',
+            'sortOrder' => 'desc; DROP',
+        ],
+        [
+            'sortBy' => ['required', 'sql_identifier'],
+            'sortOrder' => ['required', 'sort_direction'],
+        ],
+        [],
+        [
+            'sortBy' => 'sort column',
+            'sortOrder' => 'sort direction',
+        ]
+    );
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors())->toBe([
+            'sortBy' => ['The sort column must be a valid SQL identifier'],
+            'sortOrder' => ['The sort direction must be asc or desc'],
+        ])
+        ->and($validator->validated())->toBe([
+            'sortBy' => ['The sort column must be a valid SQL identifier'],
+            'sortOrder' => ['The sort direction must be asc or desc'],
+        ]);
+});
+
+test('nullable skips SQL structure validation only for values considered empty', function ($rule, $data, $expectedValidated, $fails) {
+    $validator = (new Validator())->make(
+        $data,
+        ['value' => ['nullable', $rule]]
+    );
+
+    expect($validator->fails())->toBe($fails);
+
+    if ($fails) {
+        expect($validator->errors())->toHaveKey('value');
+
+        return;
+    }
+
+    expect($validator->validated())->toBe($expectedValidated);
+})->with([
+    'sql identifier' => ['sql_identifier'],
+    'sort direction' => ['sort_direction'],
+])->with('nullable SQL structure values');


### PR DESCRIPTION
## Description

Adds reusable validation rules for simple SQL identifiers and sort directions, with end-to-end coverage for malicious sort payloads, exact errors, nullable semantics, and first-failure behavior. It also restores PHP compatibility in the nested helper, documents the SQL security boundary, and adds a PHP 5.6 parse/rule-smoke CI gate.

## Motivation & Context

Text sanitization does not make caller-controlled SQL structure safe. Consumers need explicit validation for single identifier segments and `asc`/`desc`, while database-layer allowlisting and typed identifier handling remain mandatory.

## Type of Change

- [x] New security validation feature
- [x] Backward-compatible bug fix
- [x] Tests and documentation
- [x] CI hardening

## Security Boundaries

- `sql_identifier` validates one unqualified identifier segment; it does not quote SQL.
- `sort_direction` validates `asc` or `desc`; it does not build an `ORDER BY` clause.
- `sanitize:text` and `sanitize:key` are not SQL-context controls.
- Consumers must still map public sort keys to known columns.

## Verification

- 66 tests, 137 assertions on PHP 8.5
- PHPCompatibility passes all 37 source files
- PHP 5.6 container parses all source files and passes dependency-free rule smoke checks
- Workflow YAML and `git diff --check` pass
- Independent task reviews and final whole-branch review approved

## Checklist

- [x] Code follows project style and PHP compatibility requirements
- [x] Self-review and independent code review completed
- [x] Tests added and updated
- [x] Documentation updated
- [x] No raw SQL quoting or query construction added to the validator layer

## Notes

The GitHub-hosted PHP 5.6 workflow has not yet run; local container parse/smoke verification passed. Existing Pest deprecation notices remain visible but do not fail the suite.